### PR TITLE
Create portfolio landing page

### DIFF
--- a/assets/CV-Gabriel-Morishita.pdf
+++ b/assets/CV-Gabriel-Morishita.pdf
@@ -1,0 +1,1 @@
+Placeholder CV — atualize com documento real.

--- a/assets/certificate-react.svg
+++ b/assets/certificate-react.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/assets/certificate-supabase.svg
+++ b/assets/certificate-supabase.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/assets/certificate-testing.svg
+++ b/assets/certificate-testing.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/assets/cv-qr.svg
+++ b/assets/cv-qr.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" role="img" aria-labelledby="title">
+  <title id="title">QR Code estilizado para baixar CV</title>
+  <rect width="200" height="200" fill="#0B0D12" rx="24" />
+  <rect x="16" y="16" width="56" height="56" fill="#1E90FF" rx="12" opacity="0.5" />
+  <rect x="128" y="16" width="56" height="56" fill="#1E90FF" rx="12" opacity="0.5" />
+  <rect x="16" y="128" width="56" height="56" fill="#1E90FF" rx="12" opacity="0.5" />
+  <rect x="76" y="76" width="48" height="48" fill="#1E90FF" rx="10" opacity="0.6" />
+  <rect x="132" y="96" width="40" height="40" fill="#1E90FF" rx="10" opacity="0.35" />
+  <rect x="96" y="140" width="32" height="32" fill="#1E90FF" rx="8" opacity="0.5" />
+  <rect x="52" y="108" width="28" height="28" fill="#1E90FF" rx="8" opacity="0.4" />
+  <rect x="112" y="36" width="24" height="24" fill="#1E90FF" rx="6" opacity="0.4" />
+  <rect x="156" y="152" width="24" height="24" fill="#1E90FF" rx="6" opacity="0.4" />
+  <rect x="36" y="168" width="20" height="20" fill="#1E90FF" rx="6" opacity="0.4" />
+  <rect x="168" y="80" width="16" height="16" fill="#1E90FF" rx="5" opacity="0.4" />
+</svg>

--- a/assets/financas-lite.svg
+++ b/assets/financas-lite.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/assets/gabriel-portrait.svg
+++ b/assets/gabriel-portrait.svg
@@ -1,0 +1,29 @@
+<svg width="360" height="420" viewBox="0 0 360 420" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Retrato estilizado de Gabriel</title>
+  <desc id="desc">Silhueta minimalista em tons azul marinho com detalhes em ciano</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E2F62" />
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E90FF" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#7FD4FF" stop-opacity="0.1" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="420" rx="48" fill="url(#bg)" />
+  <circle cx="180" cy="140" r="110" fill="#121826" opacity="0.7" />
+  <circle cx="180" cy="136" r="100" fill="#101a2f" />
+  <path d="M140 320C140 272 160 228 180 228C200 228 220 272 220 320" fill="#1D2B4F" />
+  <path d="M180 320C220 320 248 340 248 368C248 392 216 404 180 404C144 404 112 392 112 368C112 340 140 320 180 320Z" fill="#10192F" />
+  <path d="M124 158C128 118 158 92 180 92C202 92 232 118 236 158C236 186 226 210 208 222C200 228 160 228 152 222C134 210 124 186 124 158Z" fill="#1E2F62" />
+  <path d="M160 172C166 178 194 178 200 172" stroke="#7FD4FF" stroke-width="6" stroke-linecap="round" />
+  <circle cx="150" cy="150" r="12" fill="#0B0D12" />
+  <circle cx="210" cy="150" r="12" fill="#0B0D12" />
+  <circle cx="150" cy="150" r="6" fill="#7FD4FF" />
+  <circle cx="210" cy="150" r="6" fill="#7FD4FF" />
+  <path d="M150 118C160 110 200 110 210 118" stroke="#7FD4FF" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+  <path d="M120 212L96 220C78 226 68 248 74 266C82 290 122 298 134 276" stroke="#1E90FF" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.3" />
+  <path d="M240 212L264 220C282 226 292 248 286 266C278 290 238 298 226 276" stroke="#1E90FF" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.3" />
+  <ellipse cx="180" cy="360" rx="96" ry="46" fill="url(#glow)" opacity="0.7" />
+</svg>

--- a/assets/generic-grid.svg
+++ b/assets/generic-grid.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/assets/mass-effect-helper.svg
+++ b/assets/mass-effect-helper.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/assets/testimonial-lucas.svg
+++ b/assets/testimonial-lucas.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1A3A" />
+      <stop offset="100%" stop-color="#1E90FF" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#121826" />
+  <rect x="16" y="16" width="448" height="288" rx="24" stroke="url(#gradient)" stroke-width="4" opacity="0.4" />
+  <text x="50%" y="50%" fill="#E6EAF2" font-family="'Inter', sans-serif" font-size="28" font-weight="600" text-anchor="middle" dominant-baseline="middle">$2</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,384 @@
+<!DOCTYPE html>
+<html lang="pt-BR" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gabriel Morishita — Dev Front-end (React/TS)</title>
+  <meta name="description" content="Portfólio de Gabriel Morishita, desenvolvedor front-end focado em UI, DX e componentes reutilizáveis em React, TypeScript e Supabase.">
+  <meta property="og:title" content="Gabriel Morishita — Dev Front-end (React/TS)">
+  <meta property="og:description" content="Construo UIs rápidas e reutilizáveis. Hoje: React/TS, Supabase, Cypress.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://morishita.dev">
+  <meta property="og:image" content="https://morishita.dev/cover.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sora:wght@500;600;700&family=Space+Grotesk:wght@500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Gabriel Morishita",
+    "jobTitle": "Desenvolvedor Front-end",
+    "url": "https://morishita.dev",
+    "sameAs": [
+      "https://github.com/gabrielmorishita",
+      "https://www.linkedin.com/in/gabrielmorishita"
+    ],
+    "knowsAbout": [
+      "React",
+      "TypeScript",
+      "Supabase",
+      "Cypress",
+      "Design Systems"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <canvas id="bg-canvas" aria-hidden="true"></canvas>
+  <div class="progress-bar" aria-hidden="true"></div>
+  <header class="site-header" data-reveal>
+    <div class="container">
+      <nav class="nav">
+        <a href="#hero" class="brand" aria-label="Gabriel Morishita">GM</a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <ul class="nav__links" id="primary-nav">
+          <li><a href="#hero">Início</a></li>
+          <li><a href="#sobre">Sobre</a></li>
+          <li><a href="#stack">Stack</a></li>
+          <li><a href="#projetos">Projetos</a></li>
+          <li><a href="#experiencia">Experiência</a></li>
+          <li><a href="#resultados">Resultados</a></li>
+          <li><a href="#contato">Contato</a></li>
+        </ul>
+        <button class="theme-toggle" aria-label="Alternar tema" aria-pressed="true">
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section id="hero" class="section hero" data-reveal>
+      <div class="container hero__content">
+        <div class="hero__text">
+          <p class="eyebrow">Disponível para desafios 2025</p>
+          <h1>Dev Front-end (React/TS) — foco em UI e DX.</h1>
+          <p class="lead">Construo UIs rápidas, reutilizáveis e testáveis. Hoje estou orquestrando grids genéricos, modais dinâmicos, automações de testes E2E e integração Supabase.</p>
+          <div class="hero__cta">
+            <a class="btn btn--primary" href="#projetos" data-ripple>Ver projetos</a>
+            <a class="btn btn--ghost" href="./assets/CV-Gabriel-Morishita.pdf" download data-ripple>Baixar CV</a>
+          </div>
+          <div class="hero__meta">
+            <span class="badge badge--accent">+ Gamer</span>
+            <span>UI acessível • DX primeiro • Metas mensuráveis</span>
+          </div>
+        </div>
+        <figure class="hero__portrait" aria-labelledby="bio-photo">
+          <img src="assets/gabriel-portrait.svg" alt="Foto estilizada de Gabriel Morishita" loading="lazy" decoding="async">
+          <figcaption id="bio-photo">Focado em sistemas táticos, jogos e experiências que entregam valor.</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section id="sobre" class="section about" data-reveal>
+      <div class="container grid grid--2">
+        <div>
+          <h2>Sobre</h2>
+          <p>Sou estagiário de desenvolvimento front-end com obsessão em melhorar DX e escalar componentes. Transformo demandas confusas em experiências polidas que reduzem tempo de entrega.</p>
+          <p class="muted">Gamer nas horas vagas (estratégia, tática, UI readability). Fã de Mass Effect, Baldur's Gate 3 e puzzles que desafiam o raciocínio.</p>
+          <div class="about__now">
+            <h3>Hoje eu tô mexendo com</h3>
+            <ul class="chip-list">
+              <li class="chip" data-tooltip="Hooks com React Query, TanStack Table custom">React/TS</li>
+              <li class="chip" data-tooltip="Styled-system orientado a tokens">Styled Components</li>
+              <li class="chip" data-tooltip="Row Level Security, storage e triggers">Supabase</li>
+              <li class="chip" data-tooltip="Dashboards com Recharts e foco em acessibilidade">Recharts</li>
+              <li class="chip" data-tooltip="Cenários E2E cobrindo fluxos críticos">Cypress</li>
+            </ul>
+          </div>
+        </div>
+        <div class="about__proof">
+          <h3>Provas reais</h3>
+          <ul>
+            <li><strong>Grid genérico</strong> para CRUD, filtros avançados e clonagem em segundos.</li>
+            <li><strong>Modais dinâmicos</strong> que tratam Create/Update/Clone com DX padronizada.</li>
+            <li><strong>Testes E2E com Cypress</strong> garantindo regressões zero e performance sustentável.</li>
+          </ul>
+          <div class="about__achievements">
+            <span class="badge">100% Lighthouse</span>
+            <span class="badge">10+ componentes reutilizáveis</span>
+            <span class="badge">E2E verde 12 semanas</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="stack" class="section stack" data-reveal>
+      <div class="container">
+        <div class="section__header">
+          <div>
+            <h2>Stack & Skills</h2>
+            <p class="muted">Filtros por categoria e como aplico na prática.</p>
+          </div>
+          <div class="stack__filters" role="tablist" aria-label="Categorias de habilidades">
+            <button class="chip is-active" role="tab" aria-selected="true" data-category="all" data-ripple>Todos</button>
+            <button class="chip" role="tab" aria-selected="false" data-category="frontend" data-ripple>Frontend</button>
+            <button class="chip" role="tab" aria-selected="false" data-category="tests" data-ripple>Testes</button>
+            <button class="chip" role="tab" aria-selected="false" data-category="db" data-ripple>Dados</button>
+            <button class="chip" role="tab" aria-selected="false" data-category="tools" data-ripple>Ferramentas</button>
+          </div>
+        </div>
+        <div class="stack__grid" role="tabpanel" aria-live="polite"></div>
+        <aside class="stack__panel" aria-live="polite">
+          <h3>Como uso na prática</h3>
+          <p class="stack__details muted">Selecione uma skill para ver contexto.</p>
+          <div class="stack__gamer">
+            <h4>Badge + Gamer</h4>
+            <p>Favoritos: Baldur's Gate 3, Factorio, Into the Breach. Me ajudam a treinar leitura de sistemas, antecipar exceções e criar UIs claras para decisões rápidas.</p>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="projetos" class="section projects" data-reveal>
+      <div class="container">
+        <div class="section__header">
+          <div>
+            <h2>Projetos em Destaque</h2>
+            <p class="muted">Cada case mostra problema real, solução e resultado.</p>
+          </div>
+        </div>
+        <div class="projects__grid">
+          <article class="project-card" data-project="financas" tabindex="0">
+            <div class="project-card__media">
+              <img src="assets/financas-lite.svg" alt="Dashboard de finanças" loading="lazy" decoding="async">
+            </div>
+            <div class="project-card__body">
+              <h3>Finanças Lite</h3>
+              <p>Dashboard financeiro com Supabase, RLS e UI de contas/categorias otimizada.</p>
+              <ul>
+                <li>+32% velocidade para lançar transferências.</li>
+                <li>Esquema modelado com políticas de acesso seguras.</li>
+                <li>UI com visão consolidada por período.</li>
+              </ul>
+            </div>
+          </article>
+          <article class="project-card" data-project="grid" tabindex="0">
+            <div class="project-card__media">
+              <img src="assets/generic-grid.svg" alt="Tabela com filtros avançados" loading="lazy" decoding="async">
+            </div>
+            <div class="project-card__body">
+              <h3>Generic Grid & Modals</h3>
+              <p>Componente reutilizável que gera CRUD com filtros, colunas dinâmicas e DX amigável.</p>
+              <ul>
+                <li>Reduziu 45% do tempo de novas telas.</li>
+                <li>Combos dinâmicos e filtros tempo-only.</li>
+                <li>Modais Create/Update/Clone com validação uniforme.</li>
+              </ul>
+            </div>
+          </article>
+          <article class="project-card" data-project="helper" tabindex="0">
+            <div class="project-card__media">
+              <img src="assets/mass-effect-helper.svg" alt="Interface de companion Mass Effect" loading="lazy" decoding="async">
+            </div>
+            <div class="project-card__body">
+              <h3>Mass Effect Codex Helper</h3>
+              <p>Ferramenta para comparar builds e estratégias, com foco em acessibilidade e performance.</p>
+              <ul>
+                <li>Search instantâneo com cache em IndexedDB.</li>
+                <li>Atalhos de teclado e leitura otimizada.</li>
+                <li>UI responsiva com parallax e feedback auditivo opcional.</li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="drawer" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="drawer__overlay" data-close></div>
+      <div class="drawer__content" role="document">
+        <button class="drawer__close" data-close aria-label="Fechar detalhes">×</button>
+        <div class="drawer__inner"></div>
+      </div>
+    </section>
+
+    <section id="experiencia" class="section experience" data-reveal>
+      <div class="container">
+        <div class="section__header">
+          <h2>Experiência</h2>
+          <p class="muted">Impactos diretos em entregas, DX e performance.</p>
+        </div>
+        <ol class="timeline">
+          <li class="timeline__item">
+            <div class="timeline__marker"></div>
+            <div class="timeline__content">
+              <header>
+                <h3>Front-end Intern · Stealth SaaS</h3>
+                <span>2024 — Atual</span>
+              </header>
+              <ul>
+                <li>Implementei grid genérico que reduziu 45% do tempo de novas telas.</li>
+                <li>Orquestrei modais dinâmicos com validação compartilhada e analytics de uso.</li>
+                <li>Estabeleci suíte Cypress com 18 fluxos críticos e monitoramento diário.</li>
+              </ul>
+              <div class="timeline__tags">
+                <span class="tag">React</span>
+                <span class="tag">TypeScript</span>
+                <span class="tag">Cypress</span>
+                <span class="tag">Supabase</span>
+              </div>
+            </div>
+          </li>
+          <li class="timeline__item">
+            <div class="timeline__marker"></div>
+            <div class="timeline__content">
+              <header>
+                <h3>Product Designer Jr · Comunidade Gamer</h3>
+                <span>2022 — 2023</span>
+              </header>
+              <ul>
+                <li>Projetei HUD responsiva para eventos com +15k espectadores simultâneos.</li>
+                <li>Criei design system com tokens e estados focados em contraste e leitura.</li>
+                <li>Facilitei handoff com documentação interativa e protótipos navegáveis.</li>
+              </ul>
+              <div class="timeline__tags">
+                <span class="tag">Figma</span>
+                <span class="tag">Motion</span>
+                <span class="tag">Acessibilidade</span>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section id="resultados" class="section results" data-reveal>
+      <div class="container grid grid--2">
+        <div>
+          <h2>Resultados & Métricas</h2>
+          <p class="muted">Números que mostram impacto direto.</p>
+          <div class="counters">
+            <div class="counter" data-target="32">
+              <span class="counter__value">0</span>
+              <span class="counter__label">+ componentes reutilizáveis</span>
+            </div>
+            <div class="counter" data-target="45">
+              <span class="counter__value">0</span>
+              <span class="counter__label">− tempo para criar novas telas (%)</span>
+            </div>
+            <div class="counter" data-target="18">
+              <span class="counter__value">0</span>
+              <span class="counter__label">testes E2E estáveis</span>
+            </div>
+          </div>
+        </div>
+        <div class="results__charts">
+          <figure class="chart" aria-label="Comparativo de tempo de criação de tela antes e depois">
+            <figcaption>Tempo de criação de telas</figcaption>
+            <svg viewBox="0 0 220 120" role="img" aria-labelledby="chart-title">
+              <title id="chart-title">Tempo médio de criação de telas antes e depois</title>
+              <rect x="20" y="20" width="70" height="80" rx="12" class="chart__bar chart__bar--before"></rect>
+              <rect x="130" y="48" width="70" height="52" rx="12" class="chart__bar chart__bar--after"></rect>
+              <text x="55" y="110">Antes</text>
+              <text x="165" y="110">Depois</text>
+            </svg>
+          </figure>
+          <figure class="chart" aria-label="Comparativo de bugs críticos">
+            <figcaption>Bugs críticos</figcaption>
+            <svg viewBox="0 0 220 120" role="img" aria-labelledby="chart-bugs">
+              <title id="chart-bugs">Bugs críticos antes e depois dos testes E2E</title>
+              <polyline points="20,90 80,70 140,40 200,30" class="chart__line"></polyline>
+              <text x="20" y="105">Q1</text>
+              <text x="80" y="105">Q2</text>
+              <text x="140" y="105">Q3</text>
+              <text x="200" y="105">Q4</text>
+            </svg>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section id="certificados" class="section certificates" data-reveal>
+      <div class="container">
+        <div class="section__header">
+          <h2>Certificados & Depoimentos</h2>
+          <p class="muted">Aprendizado contínuo + voz de quem trabalhou comigo.</p>
+        </div>
+        <div class="certificates__grid">
+          <article class="certificate-card">
+            <img src="assets/certificate-react.svg" alt="Logo React" loading="lazy" decoding="async">
+            <div>
+              <h3>React Avançado</h3>
+              <a href="#">Ver certificado</a>
+            </div>
+          </article>
+          <article class="certificate-card">
+            <img src="assets/certificate-testing.svg" alt="Logo Cypress" loading="lazy" decoding="async">
+            <div>
+              <h3>Testes E2E com Cypress</h3>
+              <a href="#">Ver certificado</a>
+            </div>
+          </article>
+          <article class="certificate-card">
+            <img src="assets/certificate-supabase.svg" alt="Logo Supabase" loading="lazy" decoding="async">
+            <div>
+              <h3>Supabase Deep Dive</h3>
+              <a href="#">Ver certificado</a>
+            </div>
+          </article>
+        </div>
+        <div class="testimonials">
+          <article class="testimonial">
+            <img src="assets/testimonial-lucas.svg" alt="Foto de Lucas" loading="lazy" decoding="async">
+            <blockquote>
+              “O Gabriel transformou um backlog travado em entregas previsíveis. Os grids reutilizáveis salvaram nosso roadmap.”
+            </blockquote>
+            <cite>Lucas Andrade · Product Manager</cite>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="contato" class="section contact" data-reveal>
+      <div class="container grid grid--2">
+        <div>
+          <h2>Contato</h2>
+          <p class="lead">Vamos construir interfaces com impacto? Me chama.</p>
+          <div class="contact__actions">
+            <a class="btn btn--primary" href="https://github.com/gabrielmorishita" target="_blank" rel="noopener" data-ripple>GitHub</a>
+            <a class="btn btn--primary" href="https://www.linkedin.com/in/gabrielmorishita" target="_blank" rel="noopener" data-ripple>LinkedIn</a>
+            <button class="btn btn--ghost" type="button" data-copy="gabriel@morishita.dev" data-ripple>Copiar e-mail</button>
+          </div>
+          <div class="contact__feedback" role="status" aria-live="polite"></div>
+          <div class="contact__qr" aria-label="QR Code para baixar o CV">
+            <img src="assets/cv-qr.svg" alt="QR Code para baixar o CV" loading="lazy" decoding="async">
+          </div>
+        </div>
+        <div class="contact__roadmap">
+          <h3>Changelog / Roadmap</h3>
+          <ul>
+            <li><span class="tag">Set 2025</span> v1.0 lançado com cases e tema dinâmico.</li>
+            <li><span class="tag">Out 2025</span> Adição de métricas animadas e certificados.</li>
+            <li><span class="tag">Nov 2025</span> Depoimentos e suporte a idioma EN.</li>
+            <li><span class="tag">Jan 2026</span> Páginas detalhadas por case.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <p>Feito em HTML/CSS/JS — 100% estático.</p>
+      <p>© <span id="year"></span> Gabriel Morishita.</p>
+    </div>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,383 @@
+const docEl = document.documentElement;
+const root = document.documentElement;
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const storedTheme = localStorage.getItem('gm-theme');
+
+const applyTheme = theme => {
+  const next = theme || (prefersDark.matches ? 'dark' : 'light');
+  root.setAttribute('data-theme', next);
+  document.body.dataset.theme = next;
+  localStorage.setItem('gm-theme', next);
+  const toggle = document.querySelector('.theme-toggle');
+  if (toggle) {
+    toggle.setAttribute('aria-pressed', String(next === 'dark'));
+  }
+};
+
+applyTheme(storedTheme);
+
+prefersDark.addEventListener('change', event => {
+  if (!storedTheme) {
+    applyTheme(event.matches ? 'dark' : 'light');
+  }
+});
+
+document.querySelector('.theme-toggle')?.addEventListener('click', () => {
+  const current = root.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+});
+
+// Navigation toggle
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav__links');
+
+navToggle?.addEventListener('click', () => {
+  const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+  navToggle.setAttribute('aria-expanded', String(!expanded));
+  navLinks?.classList.toggle('is-open');
+});
+
+navLinks?.querySelectorAll('a').forEach(link => {
+  link.addEventListener('click', () => {
+    navToggle?.setAttribute('aria-expanded', 'false');
+    navLinks.classList.remove('is-open');
+  });
+});
+
+// Scroll progress bar
+const progressBar = document.querySelector('.progress-bar');
+const updateProgress = () => {
+  const scrollTop = window.scrollY;
+  const docHeight = docEl.scrollHeight - window.innerHeight;
+  const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+  progressBar.style.width = `${progress}%`;
+};
+window.addEventListener('scroll', updateProgress, { passive: true });
+updateProgress();
+
+// Ripple effect
+const createRipple = event => {
+  const button = event.currentTarget;
+  const rect = button.getBoundingClientRect();
+  const ripple = document.createElement('span');
+  const size = Math.max(rect.width, rect.height);
+  ripple.className = 'ripple';
+  ripple.style.width = ripple.style.height = `${size}px`;
+  ripple.style.left = `${event.clientX - rect.left - size / 2}px`;
+  ripple.style.top = `${event.clientY - rect.top - size / 2}px`;
+  button.appendChild(ripple);
+  setTimeout(() => ripple.remove(), 600);
+};
+
+document.querySelectorAll('[data-ripple]').forEach(button => {
+  button.addEventListener('click', createRipple);
+});
+
+// Intersection reveal animations
+const revealElements = document.querySelectorAll('[data-reveal]');
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('is-visible');
+      observer.unobserve(entry.target);
+    }
+  });
+}, {
+  threshold: 0.2,
+});
+
+revealElements.forEach(el => observer.observe(el));
+
+// Counters
+const counters = document.querySelectorAll('.counter');
+const counterObserver = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      const el = entry.target;
+      const valueEl = el.querySelector('.counter__value');
+      const target = Number(el.dataset.target) || 0;
+      const duration = 1600;
+      const start = performance.now();
+
+      const step = now => {
+        const progress = Math.min((now - start) / duration, 1);
+        const eased = progress < 0.5 ? 4 * progress * progress * progress : (progress - 1) * (2 * progress - 2) * (2 * progress - 2) + 1;
+        valueEl.textContent = Math.round(target * eased);
+        if (progress < 1) requestAnimationFrame(step);
+      };
+
+      requestAnimationFrame(step);
+      counterObserver.unobserve(el);
+    }
+  });
+}, { threshold: 0.35 });
+
+counters.forEach(counter => counterObserver.observe(counter));
+
+// Stack & skills
+const stackGrid = document.querySelector('.stack__grid');
+const stackPanel = document.querySelector('.stack__panel');
+const stackDetails = stackPanel?.querySelector('.stack__details');
+
+const skills = [
+  { name: 'React', category: 'frontend', description: 'Componentização orientada a hooks, server components experimentais e integração com TanStack Table.', proof: 'Grid genérico, dashboards responsivos e formulários dinâmicos.' },
+  { name: 'TypeScript', category: 'frontend', description: 'Modelagem de tipos utilitários, generics para modais reutilizáveis e segurança nas integrações.', proof: 'Zero any no grid, automação de contratos e DX melhorado.' },
+  { name: 'TanStack Table', category: 'frontend', description: 'Colunas dinâmicas, filtros custom e virtualização de 10k+ linhas.', proof: 'CRUD acelerado com derivação instantânea.' },
+  { name: 'Styled Components', category: 'frontend', description: 'Design system token-based, theming, variantes e dark/light.', proof: 'Tokens reutilizados em 10+ componentes com consistência visual.' },
+  { name: 'Cypress', category: 'tests', description: 'Fluxos críticos com intercept, seeds Supabase e monitoramento em CI.', proof: 'Suite diária cobrindo onboarding, billing e cadastros.' },
+  { name: 'Supabase', category: 'db', description: 'RLS, RPC functions, storage e policies.', proof: 'Finanças Lite com dados seguros e consistentes.' },
+  { name: 'Recharts', category: 'frontend', description: 'Charts acessíveis com foco em contraste e tooltips custom.', proof: 'Métricas de finanças e indicadores em real-time.' },
+  { name: 'Playwright', category: 'tests', description: 'Comparativos com Cypress e smoke tests cross-browser.', proof: 'Migração planejada para cenários paralelos.' },
+  { name: 'Figma Tokens', category: 'tools', description: 'Tokens sincronizados com código via style-dictionary.', proof: 'Handoff rápido entre design e dev.' },
+  { name: 'Notion + Linear', category: 'tools', description: 'Organização de roadmap, changelog e documentação viva.', proof: 'Squad com rituais previsíveis e histórico rastreável.' }
+];
+
+const renderSkills = (category = 'all') => {
+  if (!stackGrid) return;
+  stackGrid.innerHTML = '';
+  const filtered = category === 'all' ? skills : skills.filter(skill => skill.category === category);
+  filtered.forEach(skill => {
+    const card = document.createElement('article');
+    card.className = 'stack__item';
+    card.setAttribute('tabindex', '0');
+    card.dataset.name = skill.name;
+    card.innerHTML = `<h3>${skill.name}</h3><p class="muted">${skill.description}</p>`;
+    card.addEventListener('click', () => showSkillDetails(skill));
+    card.addEventListener('keypress', event => {
+      if (event.key === 'Enter') {
+        showSkillDetails(skill);
+      }
+    });
+    stackGrid.appendChild(card);
+  });
+};
+
+const showSkillDetails = skill => {
+  if (!stackDetails) return;
+  stackDetails.innerHTML = `<strong>${skill.name}</strong> · ${skill.description}<br><span>${skill.proof}</span>`;
+};
+
+renderSkills();
+
+const filterButtons = document.querySelectorAll('.stack__filters .chip');
+
+filterButtons.forEach(button => {
+  button.addEventListener('click', () => {
+    filterButtons.forEach(btn => btn.classList.remove('is-active'));
+    button.classList.add('is-active');
+    renderSkills(button.dataset.category);
+    const firstSkill = skills.find(skill => button.dataset.category === 'all' ? true : skill.category === button.dataset.category);
+    if (firstSkill) showSkillDetails(firstSkill);
+  });
+});
+
+if (filterButtons.length) {
+  const active = document.querySelector('.stack__filters .chip.is-active');
+  const defaultCategory = active?.dataset.category || 'all';
+  renderSkills(defaultCategory);
+  const firstSkill = skills.find(skill => defaultCategory === 'all' ? true : skill.category === defaultCategory);
+  if (firstSkill) showSkillDetails(firstSkill);
+}
+
+// Project drawer
+const projectData = {
+  financas: {
+    title: 'Finanças Lite',
+    problem: 'Gestores precisavam consolidar contas, categorias e transferências com segurança multiusuário.',
+    solution: 'Modelagem Supabase com RLS, interface de contas com drag-and-drop e grid com filtros por período.',
+    result: '+32% velocidade no lançamento de transferências e redução de tickets de suporte.',
+    stack: ['React', 'TypeScript', 'Supabase', 'TanStack Table', 'Styled Components'],
+    images: ['assets/financas-lite.svg']
+  },
+  grid: {
+    title: 'Generic Grid & Modals',
+    problem: 'Criar novas telas levava dias por falta de componentes padronizados e filtros reutilizáveis.',
+    solution: 'Grid declarativo com schema JSON, modais dinâmicos Create/Update/Clone e validação unificada.',
+    result: '45% de redução no tempo de entrega e documentação DX para o squad.',
+    stack: ['React', 'TypeScript', 'TanStack Table', 'Zod', 'Cypress'],
+    images: ['assets/generic-grid.svg']
+  },
+  helper: {
+    title: 'Mass Effect Codex Helper',
+    problem: 'Jogadores perdiam tempo comparando builds e lendo informação fragmentada em wikis.',
+    solution: 'Interface com busca instantânea, visão comparativa e atalhos acessíveis.',
+    result: 'Sessões mais curtas e aumento de retenção no protótipo público.',
+    stack: ['React', 'TypeScript', 'IndexedDB', 'Accessibility'],
+    images: ['assets/mass-effect-helper.svg']
+  }
+};
+
+const drawer = document.querySelector('.drawer');
+const drawerContent = drawer?.querySelector('.drawer__inner');
+
+const openDrawer = key => {
+  if (!drawer || !drawerContent) return;
+  const data = projectData[key];
+  if (!data) return;
+  drawerContent.innerHTML = `
+    <header>
+      <h2>${data.title}</h2>
+      <div class="badge badge--accent">Case</div>
+    </header>
+    <section>
+      <h3>Problema</h3>
+      <p>${data.problem}</p>
+    </section>
+    <section>
+      <h3>Solução</h3>
+      <p>${data.solution}</p>
+    </section>
+    <section>
+      <h3>Resultado</h3>
+      <p>${data.result}</p>
+    </section>
+    <section>
+      <h3>Stack utilizada</h3>
+      <div class="chip-list">${data.stack.map(item => `<span class="chip">${item}</span>`).join('')}</div>
+    </section>
+    <section>
+      <h3>Evidências</h3>
+      <div class="project__gallery">${data.images.map(src => `<img src="${src}" alt="${data.title}" loading="lazy" decoding="async">`).join('')}</div>
+    </section>
+  `;
+  drawer.setAttribute('aria-hidden', 'false');
+  drawer.classList.add('is-open');
+  document.body.style.overflow = 'hidden';
+};
+
+const closeDrawer = () => {
+  if (!drawer) return;
+  drawer.classList.remove('is-open');
+  drawer.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+};
+
+drawer?.querySelectorAll('[data-close]').forEach(btn => {
+  btn.addEventListener('click', closeDrawer);
+});
+
+document.addEventListener('keydown', event => {
+  if (event.key === 'Escape') closeDrawer();
+});
+
+document.querySelectorAll('.project-card').forEach(card => {
+  card.addEventListener('click', () => openDrawer(card.dataset.project));
+  card.addEventListener('keypress', event => {
+    if (event.key === 'Enter') openDrawer(card.dataset.project);
+  });
+});
+
+// Copy email
+const copyButtons = document.querySelectorAll('[data-copy]');
+const feedbackEl = document.querySelector('.contact__feedback');
+
+copyButtons.forEach(button => {
+  button.addEventListener('click', async () => {
+    const value = button.dataset.copy;
+    try {
+      await navigator.clipboard.writeText(value);
+      if (feedbackEl) {
+        feedbackEl.textContent = 'E-mail copiado!';
+        setTimeout(() => (feedbackEl.textContent = ''), 2400);
+      }
+    } catch (error) {
+      if (feedbackEl) {
+        feedbackEl.textContent = value;
+      }
+    }
+  });
+});
+
+// Year
+const year = document.getElementById('year');
+year.textContent = new Date().getFullYear();
+
+// Background canvas particles
+const canvas = document.getElementById('bg-canvas');
+const ctx = canvas?.getContext('2d');
+let particles = [];
+
+const resizeCanvas = () => {
+  if (!canvas) return;
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  particles = Array.from({ length: Math.min(160, Math.floor(canvas.width / 12)) }, () => ({
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+    radius: Math.random() * 1.4 + 0.4,
+    alpha: Math.random() * 0.4 + 0.1,
+    speedY: (Math.random() - 0.5) * 0.08,
+    speedX: (Math.random() - 0.5) * 0.08
+  }));
+};
+
+const drawParticles = () => {
+  if (!ctx || !canvas) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  particles.forEach(particle => {
+    ctx.beginPath();
+    ctx.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(127, 212, 255, ${particle.alpha})`;
+    ctx.fill();
+    particle.x += particle.speedX;
+    particle.y += particle.speedY;
+    if (particle.x > canvas.width) particle.x = 0;
+    if (particle.x < 0) particle.x = canvas.width;
+    if (particle.y > canvas.height) particle.y = 0;
+    if (particle.y < 0) particle.y = canvas.height;
+  });
+  requestAnimationFrame(drawParticles);
+};
+
+if (canvas) {
+  resizeCanvas();
+  drawParticles();
+  window.addEventListener('resize', resizeCanvas);
+}
+
+// Scroll reveal parallax
+const hero = document.querySelector('.hero');
+window.addEventListener('scroll', () => {
+  if (!hero) return;
+  const offset = window.scrollY * 0.1;
+  hero.style.backgroundPosition = `center ${offset}px`;
+}, { passive: true });
+
+// Konami code easter egg
+const KONAMI = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+let konamiIndex = 0;
+
+document.addEventListener('keydown', event => {
+  const key = event.key;
+  if (key === KONAMI[konamiIndex]) {
+    konamiIndex += 1;
+    if (konamiIndex === KONAMI.length) {
+      konamiIndex = 0;
+      document.body.classList.add('konami-mode');
+      setTimeout(() => document.body.classList.remove('konami-mode'), 10000);
+    }
+  } else {
+    konamiIndex = 0;
+  }
+});
+
+// Lightbox keyboard trap when drawer is open
+const trapFocus = event => {
+  if (!drawer?.classList.contains('is-open')) return;
+  const focusable = drawer.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (event.key !== 'Tab') return;
+  if (event.shiftKey) {
+    if (document.activeElement === first) {
+      last.focus();
+      event.preventDefault();
+    }
+  } else if (document.activeElement === last) {
+    first.focus();
+    event.preventDefault();
+  }
+};
+
+document.addEventListener('keydown', trapFocus);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,808 @@
+:root {
+  --font-display: 'Sora', 'Space Grotesk', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, sans-serif;
+  --color-bg: #0b0d12;
+  --color-surface: rgba(18, 24, 38, 0.9);
+  --color-surface-strong: #121826;
+  --color-text: #e6eaf2;
+  --color-muted: rgba(230, 234, 242, 0.6);
+  --color-primary: #1e90ff;
+  --color-primary-soft: rgba(30, 144, 255, 0.12);
+  --color-accent: #ffd166;
+  --color-outline: rgba(230, 234, 242, 0.12);
+  --color-glass: rgba(13, 20, 32, 0.6);
+  --shadow-soft: 0 24px 48px rgba(8, 10, 26, 0.35);
+  --shadow-card: 0 18px 40px rgba(10, 16, 34, 0.25);
+  --radius-12: 12px;
+  --radius-16: 16px;
+  --space-8: 8px;
+  --space-16: 16px;
+  --space-24: 24px;
+  --space-32: 32px;
+  --space-48: 48px;
+  --container-width: min(1200px, 90vw);
+  color-scheme: dark;
+}
+
+[data-theme='light'] {
+  --color-bg: #f5f7fb;
+  --color-surface: rgba(255, 255, 255, 0.86);
+  --color-surface-strong: #ffffff;
+  --color-text: #0b0d12;
+  --color-muted: rgba(11, 13, 18, 0.68);
+  --color-outline: rgba(11, 13, 18, 0.08);
+  --color-glass: rgba(255, 255, 255, 0.7);
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  background: var(--color-bg);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--color-text);
+  background: radial-gradient(circle at top left, rgba(30, 144, 255, 0.12), transparent 55%), radial-gradient(circle at bottom right, rgba(255, 209, 102, 0.08), transparent 55%), var(--color-bg);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: var(--radius-16);
+  object-fit: cover;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+[tabindex="0"]:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
+  border-radius: var(--radius-12);
+}
+
+.container {
+  width: var(--container-width);
+  margin: 0 auto;
+  padding: 0 var(--space-16);
+}
+
+.section {
+  padding: calc(var(--space-48) * 2) 0;
+}
+
+.section h2 {
+  font-family: var(--font-display);
+  font-size: clamp(32px, 5vw, 48px);
+  margin-bottom: var(--space-16);
+}
+
+.section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: var(--space-32);
+  margin-bottom: var(--space-32);
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+.hero {
+  position: relative;
+  min-height: 88vh;
+  display: flex;
+  align-items: center;
+}
+
+.hero__content {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--space-32);
+  align-items: center;
+}
+
+.hero__text {
+  grid-column: span 7;
+}
+
+.hero__text h1 {
+  font-family: var(--font-display);
+  font-size: clamp(48px, 7vw, 64px);
+  line-height: 1.1;
+  margin-bottom: var(--space-24);
+}
+
+.hero__text .lead {
+  font-size: 20px;
+  color: var(--color-muted);
+  margin-bottom: var(--space-32);
+}
+
+.hero__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-16);
+  margin-top: var(--space-24);
+  color: var(--color-muted);
+}
+
+.hero__portrait {
+  grid-column: span 5;
+  position: relative;
+  justify-self: end;
+  max-width: 360px;
+}
+
+.hero__portrait img {
+  box-shadow: var(--shadow-card);
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 14px;
+  color: var(--color-muted);
+  margin-bottom: var(--space-16);
+}
+
+.btn {
+  position: relative;
+  font-family: var(--font-body);
+  font-weight: 600;
+  padding: 14px 28px;
+  border-radius: var(--radius-16);
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-8);
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+  overflow: hidden;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, rgba(30, 144, 255, 0.9), rgba(127, 212, 255, 0.4));
+  color: var(--color-text);
+  box-shadow: 0 18px 40px rgba(30, 144, 255, 0.24);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: rgba(230, 234, 242, 0.24);
+  color: var(--color-text);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+}
+
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+  transform: scale(0);
+  animation: ripple 600ms ease-out;
+  pointer-events: none;
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(3.2);
+    opacity: 0;
+  }
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(230, 234, 242, 0.08);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.badge--accent {
+  background: rgba(30, 144, 255, 0.18);
+  color: var(--color-primary);
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-32);
+}
+
+.grid--2 {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-12, 12px);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.chip,
+.tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(230, 234, 242, 0.18);
+  background: rgba(230, 234, 242, 0.04);
+  font-size: 15px;
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+}
+
+.chip:hover,
+.chip.is-active,
+.tag:hover {
+  transform: translateY(-2px);
+  border-color: rgba(30, 144, 255, 0.5);
+  box-shadow: 0 12px 24px rgba(30, 144, 255, 0.18);
+}
+
+.chip[data-tooltip] {
+  position: relative;
+}
+
+.chip[data-tooltip]:hover::after,
+.chip[data-tooltip]:focus-visible::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 12px;
+  border-radius: var(--radius-12);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-soft);
+  color: var(--color-text);
+  font-size: 14px;
+  min-width: 200px;
+  text-align: center;
+  z-index: 3;
+}
+
+.about__achievements {
+  margin-top: var(--space-24);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+}
+
+.stack {
+  position: relative;
+}
+
+.stack__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-24);
+}
+
+.stack__item {
+  padding: var(--space-24);
+  border-radius: var(--radius-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-soft);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+  cursor: pointer;
+}
+
+.stack__item:hover {
+  transform: translateY(-4px);
+}
+
+.stack__panel {
+  margin-top: var(--space-32);
+  padding: var(--space-32);
+  border-radius: var(--radius-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-soft);
+}
+
+.stack__panel h3 {
+  margin-top: 0;
+}
+
+.stack__gamer {
+  margin-top: var(--space-24);
+  padding: var(--space-24);
+  border-radius: var(--radius-16);
+  background: linear-gradient(135deg, rgba(30, 144, 255, 0.18), rgba(127, 212, 255, 0.08));
+}
+
+.projects__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-32);
+}
+
+.project-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: var(--radius-16);
+  box-shadow: var(--shadow-soft);
+  padding: var(--space-24);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-24);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.project-card:hover,
+.project-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-card);
+}
+
+.project-card__media {
+  border-radius: var(--radius-16);
+  overflow: hidden;
+}
+
+.project-card__body ul {
+  margin: 0;
+  padding-left: 1.2em;
+  color: var(--color-muted);
+}
+
+.drawer {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: stretch;
+  justify-content: flex-end;
+  background: rgba(8, 10, 26, 0.55);
+  backdrop-filter: blur(12px);
+  z-index: 20;
+}
+
+.drawer.is-open {
+  display: flex;
+}
+
+.drawer__content {
+  width: min(520px, 90vw);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-card);
+  border-radius: 24px 0 0 24px;
+  padding: var(--space-32);
+  overflow-y: auto;
+}
+
+.drawer__inner h3 {
+  font-family: var(--font-display);
+}
+
+.drawer__inner section {
+  margin-bottom: var(--space-32);
+}
+
+.project__gallery {
+  display: grid;
+  gap: var(--space-16);
+}
+
+.drawer__close {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: 28px;
+  cursor: pointer;
+  position: absolute;
+  top: var(--space-24);
+  right: var(--space-24);
+}
+
+[data-theme='dark'] .drawer__content {
+  background: rgba(18, 24, 38, 0.96);
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-left: 2px solid rgba(230, 234, 242, 0.12);
+  display: grid;
+  gap: var(--space-32);
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: var(--space-32);
+}
+
+.timeline__marker {
+  position: absolute;
+  top: 0;
+  left: -12px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  box-shadow: 0 0 0 6px rgba(30, 144, 255, 0.16);
+}
+
+.timeline__content header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-16);
+  margin-bottom: var(--space-16);
+}
+
+.timeline__content ul {
+  margin: 0 0 var(--space-16);
+  padding-left: 1.2em;
+}
+
+.timeline__tags {
+  display: flex;
+  gap: var(--space-8);
+  flex-wrap: wrap;
+}
+
+.tag {
+  background: rgba(30, 144, 255, 0.12);
+  border: none;
+  color: var(--color-primary);
+  cursor: default;
+}
+
+.counters {
+  display: grid;
+  gap: var(--space-24);
+}
+
+.counter {
+  padding: var(--space-24);
+  border-radius: var(--radius-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-soft);
+}
+
+.counter__value {
+  font-family: var(--font-display);
+  font-size: 44px;
+  display: block;
+}
+
+.results__charts {
+  display: grid;
+  gap: var(--space-24);
+}
+
+.chart {
+  padding: var(--space-24);
+  border-radius: var(--radius-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+}
+
+.chart svg {
+  width: 100%;
+  height: auto;
+}
+
+.chart__bar--before {
+  fill: rgba(230, 234, 242, 0.18);
+}
+
+.chart__bar--after {
+  fill: rgba(30, 144, 255, 0.55);
+}
+
+.chart__line {
+  fill: none;
+  stroke: var(--color-primary);
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 12px 16px rgba(30, 144, 255, 0.2));
+}
+
+.certificates__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-24);
+}
+
+.certificate-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-16);
+  padding: var(--space-24);
+  border-radius: var(--radius-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-soft);
+  transition: transform 200ms ease;
+}
+
+.certificate-card:hover {
+  transform: translateY(-4px);
+}
+
+.testimonials {
+  margin-top: var(--space-32);
+  display: grid;
+  gap: var(--space-24);
+}
+
+.testimonial {
+  padding: var(--space-24);
+  border-radius: var(--radius-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-16);
+  grid-template-columns: auto 1fr;
+  align-items: center;
+}
+
+.testimonial blockquote {
+  margin: 0;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.contact__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+  margin-bottom: var(--space-24);
+}
+
+.contact__feedback {
+  min-height: 24px;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.contact__roadmap ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: var(--space-16);
+}
+
+.contact__qr img {
+  width: 160px;
+  height: auto;
+}
+
+.site-footer {
+  padding: var(--space-24) 0;
+  background: rgba(10, 16, 30, 0.8);
+  backdrop-filter: blur(12px);
+}
+
+.footer__inner {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+  font-size: 14px;
+  color: var(--color-muted);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: var(--space-16) 0;
+  background: rgba(11, 13, 18, 0.6);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(230, 234, 242, 0.06);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-24);
+}
+
+.brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.2em;
+}
+
+.nav__links {
+  display: flex;
+  gap: var(--space-16);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav__links a {
+  padding: 10px 16px;
+  border-radius: var(--radius-12);
+  color: var(--color-muted);
+  transition: color 200ms ease, background 200ms ease;
+}
+
+.nav__links a:hover,
+.nav__links a:focus-visible {
+  color: var(--color-text);
+  background: rgba(230, 234, 242, 0.08);
+}
+
+.theme-toggle,
+.nav-toggle {
+  background: rgba(230, 234, 242, 0.08);
+  border: 1px solid rgba(230, 234, 242, 0.16);
+  border-radius: var(--radius-12);
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  position: relative;
+}
+
+.theme-toggle__icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at top, #ffd166 0%, #ffd166 45%, transparent 55%), radial-gradient(circle at bottom, rgba(30, 144, 255, 0.6), rgba(18, 28, 60, 0.1));
+  transition: transform 300ms ease;
+}
+
+[data-theme='light'] .theme-toggle__icon {
+  transform: rotate(180deg);
+  background: radial-gradient(circle at top, #0a1a3a 0%, #1e90ff 45%, transparent 55%), radial-gradient(circle at bottom, rgba(255, 209, 102, 0.6), rgba(255, 209, 102, 0.1));
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nav-toggle__line {
+  width: 20px;
+  height: 2px;
+  background: var(--color-text);
+  display: block;
+}
+
+.progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 3px;
+  background: linear-gradient(90deg, rgba(30, 144, 255, 0.8), rgba(127, 212, 255, 0.8));
+  z-index: 30;
+}
+
+#bg-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -2;
+}
+
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 600ms ease, transform 600ms ease;
+}
+
+[data-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.konami-mode {
+  animation: konami 800ms ease-in-out infinite alternate;
+}
+
+@keyframes konami {
+  from {
+    filter: hue-rotate(0deg) saturate(1.1);
+  }
+  to {
+    filter: hue-rotate(35deg) saturate(1.4);
+  }
+}
+
+@media (max-width: 960px) {
+  .hero__content {
+    grid-template-columns: repeat(6, 1fr);
+  }
+  .hero__text {
+    grid-column: span 6;
+  }
+  .hero__portrait {
+    grid-column: span 6;
+    justify-self: start;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 16px;
+  }
+  .nav__links {
+    position: absolute;
+    top: 72px;
+    right: 16px;
+    flex-direction: column;
+    background: var(--color-surface);
+    padding: var(--space-24);
+    border-radius: var(--radius-16);
+    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--color-outline);
+    display: none;
+  }
+  .nav__links.is-open {
+    display: flex;
+  }
+  .nav-toggle {
+    display: inline-flex;
+  }
+  .section {
+    padding: calc(var(--space-48) * 1.5) 0;
+  }
+  .hero__text h1 {
+    font-size: clamp(36px, 11vw, 52px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  [data-reveal] {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- build single-page portfolio layout with hero, stack, projetos, experiência e roadmap seguindo estética navy glassmorphism
- implement dark/light theme tokens, navegação responsiva, animações de scroll, ripple e easter egg Konami sem dependências externas
- adicionar drawer de projetos, contadores animados, filtros de skills, cópia de e-mail e canvas de partículas com ativos SVG placeholder

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d8b2bb71c8833282fdccdf0ab45c75