### PR TITLE
Redesign hero section for dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,31 +75,28 @@
       <div class="hero__grain" aria-hidden="true"></div>
       <div class="container hero__content">
         <div class="hero__column hero__column--text">
-          <p class="eyebrow hero__eyebrow">Disponível para desafios 2025</p>
+          <p class="hero__tagline">Vitor Costa — disponível para desafios 2025</p>
           <h1 class="hero__title">
             Dev Front-end (React/TS) —
-            <span class="hero__ticker" data-terms="UI e DX|Design Systems|Experiências consistentes" aria-live="polite">
-              <span class="hero__ticker-text">UI e DX</span>
-              <span class="hero__ticker-cursor" aria-hidden="true"></span>
-            </span>
+            <span class="hero__title-highlight">UI e DX</span>
           </h1>
-          <p class="hero__lead">Entrego interfaces React/TS com DX mensurável: componentização madura, design system vivo e releases com menos atrito.</p>
-          <div class="hero__cta">
-            <a class="btn btn--primary" href="#projetos" data-ripple>Ver projetos</a>
-            <a class="btn btn--secondary" href="./assets/Curriculo.pdf" download data-ripple>Baixar CV</a>
+          <p class="hero__subtitle">componentização, CRUDs padronizados, Supabase com RLS, suíte E2E</p>
+          <div class="hero__actions">
+            <a class="btn btn--primary hero__action" href="#projetos" data-ripple>Ver projetos</a>
+            <a class="btn btn--secondary hero__action" href="./assets/Curriculo.pdf" download data-ripple>Baixar CV</a>
           </div>
-          <ul class="hero__metrics" aria-label="Impacto recente">
-            <li class="metric-chip">
-              <span class="metric-chip__value">–42%</span>
-              <span class="metric-chip__label">tempo p/ nova tela</span>
+          <ul class="hero__proofs" aria-label="Resultados recentes">
+            <li class="hero__proof-chip">
+              <span class="hero__proof-value">–42%</span>
+              <span class="hero__proof-label">tempo p/ nova tela</span>
             </li>
-            <li class="metric-chip">
-              <span class="metric-chip__value">+33%</span>
-              <span class="metric-chip__label">componentes</span>
+            <li class="hero__proof-chip">
+              <span class="hero__proof-value">+33%</span>
+              <span class="hero__proof-label">componentes</span>
             </li>
-            <li class="metric-chip">
-              <span class="metric-chip__value">+9pp</span>
-              <span class="metric-chip__label">cobertura E2E</span>
+            <li class="hero__proof-chip">
+              <span class="hero__proof-value">+9pp</span>
+              <span class="hero__proof-label">cobertura E2E</span>
             </li>
           </ul>
           <div class="hero__scroll-hint" aria-hidden="true">
@@ -108,23 +105,18 @@
           </div>
         </div>
         <div class="hero__column hero__column--visual">
-          <figure class="hero__visual-card" data-tilt aria-labelledby="hero-visual-caption">
-            <div class="hero__visual-glow" aria-hidden="true"></div>
-            <div class="hero__visual-grid">
-              <div class="hero__project hero__project--primary" data-depth="3">
-                <img src="assets/finance-life.png" alt="" loading="lazy" decoding="async" />
-                <span class="hero__project-label">Finanças Lite</span>
-              </div>
-              <div class="hero__project hero__project--secondary" data-depth="2">
-                <img src="assets/genericGrid.png" alt="" loading="lazy" decoding="async" />
-                <span class="hero__project-label">Grid &amp; Modais</span>
-              </div>
-              <div class="hero__project hero__project--tertiary" data-depth="2.5">
-                <img src="assets/Suite de Testes E2E.png" alt="" loading="lazy" decoding="async" />
-                <span class="hero__project-label">Suite E2E</span>
+          <figure class="hero__profile-card" data-tilt aria-labelledby="hero-visual-caption">
+            <div class="hero__profile-glow" aria-hidden="true"></div>
+            <div class="hero__profile-surface hero__parallax-layer" data-depth="1.2">
+              <div class="hero__profile-frame">
+                <img class="hero__profile-image" src="assets/perfilpixel.png" alt="Retrato pixel-art de Vitor Costa" loading="lazy" decoding="async" />
               </div>
             </div>
-            <figcaption id="hero-visual-caption" class="sr-only">Mosaico de projetos recentes com foco em finanças, grid genérico e testes end-to-end.</figcaption>
+            <div class="hero__profile-badge hero__parallax-layer" data-depth="2.4">
+              <span class="hero__profile-name">Vitor Costa</span>
+              <span class="hero__profile-role">Dev • Gamer</span>
+            </div>
+            <figcaption id="hero-visual-caption" class="sr-only">Retrato pixel-art de Vitor Costa com borda gradiente azul e roxa.</figcaption>
           </figure>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -149,9 +149,9 @@ if (tickerRoot) {
 }
 
 // Hero tilt effect
-const heroTiltCard = document.querySelector('.hero__visual-card[data-tilt]');
+const heroTiltCard = document.querySelector('.hero__profile-card[data-tilt]');
 if (heroTiltCard) {
-  const layers = heroTiltCard.querySelectorAll('.hero__project');
+  const layers = heroTiltCard.querySelectorAll('[data-depth]');
   let tiltAttached = false;
 
   const applyTilt = (event) => {
@@ -159,20 +159,16 @@ if (heroTiltCard) {
     if (!rect.width || !rect.height) return;
     const x = (event.clientX - rect.left) / rect.width;
     const y = (event.clientY - rect.top) / rect.height;
-    const rotateX = (0.5 - y) * 16;
-    const rotateY = (x - 0.5) * 16;
+    const rotateX = (0.5 - y) * 12;
+    const rotateY = (x - 0.5) * 12;
     heroTiltCard.style.setProperty('--tilt-rotate-x', `${rotateX.toFixed(2)}deg`);
     heroTiltCard.style.setProperty('--tilt-rotate-y', `${rotateY.toFixed(2)}deg`);
 
     layers.forEach((layer) => {
       const depth = Number(layer.dataset.depth) || 1;
-      const translateX = (x - 0.5) * depth * 18;
-      const translateY = (y - 0.5) * depth * 18;
-      layer.style.transform = `translate3d(${translateX}px, ${translateY}px, ${depth * 6}px)`;
-      const image = layer.querySelector('img');
-      if (image) {
-        image.style.transform = `scale(1.02) translate3d(${translateX * 0.4}px, ${translateY * 0.4}px, 0)`;
-      }
+      const translateX = (x - 0.5) * depth * 14;
+      const translateY = (y - 0.5) * depth * 14;
+      layer.style.transform = `translate3d(${translateX}px, ${translateY}px, ${depth * 5}px)`;
     });
   };
 
@@ -181,8 +177,6 @@ if (heroTiltCard) {
     heroTiltCard.style.setProperty('--tilt-rotate-y', '0deg');
     layers.forEach((layer) => {
       layer.style.transform = 'translate3d(0, 0, 0)';
-      const image = layer.querySelector('img');
-      if (image) image.style.transform = 'scale(1) translate3d(0, 0, 0)';
     });
   };
 

--- a/styles.css
+++ b/styles.css
@@ -201,63 +201,77 @@ button:focus-visible,
   align-items: center;
 }
 
+
 .hero__column {
   display: flex;
   flex-direction: column;
-  gap: var(--space-24);
+  gap: clamp(var(--space-24), 4vw, var(--space-32));
 }
 
-.hero__column--text { grid-column: span 7; }
+.hero__column--text {
+  grid-column: span 7;
+  gap: clamp(var(--space-16), 3vw, var(--space-24));
+  align-items: flex-start;
+  max-width: 620px;
+}
+
+.hero__tagline {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-12);
+  font-size: 15px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.76);
+  margin: 0;
+}
+
+.hero__tagline::before {
+  content: "";
+  display: inline-block;
+  width: 46px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.8), rgba(129, 140, 248, 0));
+}
 
 .hero__title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: clamp(52px, 8vw, 76px);
-  line-height: 1.05;
-  font-weight: 700;
+  font-size: clamp(48px, 8vw, 82px);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
   color: var(--color-text);
+  text-wrap: balance;
 }
 
-.hero__ticker {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--color-highlight);
-  position: relative;
+.hero__title-highlight {
+  display: inline-block;
+  background: linear-gradient(120deg, #60a5fa 0%, #a855f7 55%, #f472b6 100%);
+  -webkit-background-clip: text;
+  color: transparent;
 }
 
-.hero__ticker-text {
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.hero__ticker-cursor {
-  width: 2px;
-  height: 1.1em;
-  background: currentColor;
-  border-radius: 2px;
-  animation: hero-cursor 1.1s steps(2, start) infinite;
-  align-self: flex-end;
-}
-
-@keyframes hero-cursor {
-  to { opacity: 0; }
-}
-
-.hero__lead {
+.hero__subtitle {
   margin: 0;
-  font-size: clamp(18px, 2.2vw, 20px);
-  color: var(--color-muted);
-  max-width: 520px;
+  font-size: clamp(18px, 2.1vw, 22px);
+  color: rgba(226, 232, 240, 0.72);
+  max-width: 540px;
+  letter-spacing: 0.01em;
 }
 
-.hero__cta {
+.hero__actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-16);
 }
 
-.hero__metrics {
+.hero__action {
+  min-width: 160px;
+}
+
+.hero__proofs {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-16);
@@ -266,27 +280,28 @@ button:focus-visible,
   list-style: none;
 }
 
-.metric-chip {
+.hero__proof-chip {
   display: inline-flex;
   align-items: center;
   gap: var(--space-12);
-  padding: 12px 18px;
+  padding: 14px 20px;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(15, 23, 42, 0.55);
-  box-shadow: 0 18px 40px rgba(8, 12, 24, 0.45);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+  box-shadow: 0 24px 52px rgba(15, 23, 42, 0.45);
   backdrop-filter: blur(18px);
+  isolation: isolate;
 }
 
-.metric-chip__value {
-  font-weight: 800;
+.hero__proof-value {
   font-size: 18px;
-  color: var(--color-highlight);
+  font-weight: 700;
+  color: #60a5fa;
 }
 
-.metric-chip__label {
+.hero__proof-label {
   font-size: 15px;
-  color: rgba(226, 232, 240, 0.85);
+  color: rgba(226, 232, 240, 0.82);
   white-space: nowrap;
 }
 
@@ -345,91 +360,92 @@ button:focus-visible,
   justify-content: flex-end;
 }
 
-.hero__visual-card {
+.hero__profile-card {
   position: relative;
   width: min(420px, 100%);
-  aspect-ratio: 3 / 4;
-  padding: var(--space-24);
+  padding: 2px;
   border-radius: 32px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: linear-gradient(150deg, rgba(15, 23, 42, 0.9) 0%, rgba(30, 41, 59, 0.75) 50%, rgba(51, 65, 85, 0.7) 100%);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(129, 140, 248, 0.65), rgba(236, 72, 153, 0.5));
   box-shadow: 0 38px 88px rgba(2, 6, 23, 0.55);
-  backdrop-filter: blur(28px);
-  overflow: hidden;
   transform-style: preserve-3d;
-  transform: perspective(1200px) rotateX(var(--tilt-rotate-x, 0deg)) rotateY(var(--tilt-rotate-y, 0deg));
-  transition: transform 220ms ease, box-shadow 220ms ease;
-}
-
-.hero__visual-card:hover { box-shadow: 0 45px 110px rgba(2, 6, 23, 0.6); }
-
-.hero__visual-glow {
-  position: absolute;
-  inset: 12%;
-  background: radial-gradient(65% 65% at 50% 30%, rgba(99, 102, 241, 0.35), transparent 80%);
-  filter: blur(48px);
-  opacity: 0.75;
-}
-
-.hero__visual-grid {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--space-16);
-  height: 100%;
-}
-
-.hero__project {
-  position: relative;
-  border-radius: 24px;
-  overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  background: rgba(15, 23, 42, 0.55);
-  box-shadow: 0 18px 44px rgba(8, 12, 24, 0.55);
+  transform: perspective(1300px) rotateX(var(--tilt-rotate-x, 0deg)) rotateY(var(--tilt-rotate-y, 0deg));
+  transition: transform 260ms ease, box-shadow 260ms ease;
   isolation: isolate;
-  display: flex;
-  align-items: flex-end;
-  padding: var(--space-16);
-  transform-style: preserve-3d;
-  transition: transform 200ms ease;
 }
 
-.hero__project--primary { grid-column: span 2; aspect-ratio: 12 / 7; }
+.hero__profile-card:hover,
+.hero__profile-card:focus-within {
+  box-shadow: 0 48px 120px rgba(2, 6, 23, 0.68);
+}
 
-.hero__project--secondary,
-.hero__project--tertiary { aspect-ratio: 1; }
-
-.hero__project img {
+.hero__profile-glow {
   position: absolute;
-  inset: 0;
+  inset: -18%;
+  background: radial-gradient(70% 70% at 50% 35%, rgba(37, 99, 235, 0.55), transparent 75%);
+  filter: blur(80px);
+  opacity: 0.9;
+  z-index: -2;
+}
+
+.hero__profile-surface {
+  position: relative;
+  border-radius: inherit;
+  background: linear-gradient(160deg, rgba(8, 12, 24, 0.8) 0%, rgba(13, 20, 34, 0.92) 55%, rgba(17, 24, 39, 0.86) 100%);
+  backdrop-filter: blur(22px);
+  padding: clamp(22px, 5vw, 32px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.hero__profile-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  border-radius: clamp(24px, 4vw, 28px);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.22);
+}
+
+.hero__profile-image {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: saturate(1.05);
-  opacity: 0.92;
-  transition: transform 220ms ease;
 }
 
-.hero__project::after {
-  content: "";
+.hero__profile-badge {
   position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 30%, rgba(10, 15, 25, 0.78) 100%);
-}
-
-.hero__project-label {
-  position: relative;
-  z-index: 1;
-  padding: 6px 12px;
+  top: 28px;
+  left: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  font-size: 14px;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.96);
   font-weight: 600;
-  letter-spacing: 0.04em;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 46px rgba(15, 23, 42, 0.55);
 }
 
-.hero__visual-card figcaption { margin: 0; }
+.hero__profile-name {
+  font-weight: 700;
+}
+
+.hero__profile-role {
+  color: rgba(148, 163, 184, 0.96);
+  font-weight: 500;
+}
+
+.hero__parallax-layer {
+  transform-style: preserve-3d;
+  will-change: transform;
+  transition: transform 260ms ease;
+}
+
+.hero__profile-card figcaption { margin: 0; }
 
 @media (max-width: 1200px) {
   .hero { padding: clamp(100px, 16vh, 140px) 0; }
@@ -447,11 +463,11 @@ button:focus-visible,
   .hero__column--visual {
     justify-content: center;
   }
-  .hero__visual-card {
+  .hero__profile-card {
     margin-top: var(--space-32);
     width: min(440px, 100%);
   }
-  .hero__metrics {
+  .hero__proofs {
     justify-content: flex-start;
   }
 }
@@ -461,24 +477,34 @@ button:focus-visible,
   .hero__title {
     font-size: clamp(40px, 10vw, 56px);
   }
-  .hero__ticker { gap: 6px; }
-  .hero__metrics {
+  .hero__proofs {
     flex-direction: column;
     align-items: stretch;
   }
-  .metric-chip {
+  .hero__proof-chip {
     width: 100%;
     justify-content: space-between;
   }
-  .metric-chip__label {
+  .hero__proof-label {
     white-space: normal;
   }
   .hero__scroll-hint {
     margin-top: var(--space-16);
   }
-  .hero__visual-card {
+  .hero__profile-card {
     width: 100%;
     aspect-ratio: 7 / 9;
+  }
+  .hero__profile-badge {
+    top: 18px;
+    left: 18px;
+    padding: 8px 14px;
+    gap: 8px;
+    font-size: 14px;
+  }
+  .hero__tagline {
+    font-size: 14px;
+    letter-spacing: 0.08em;
   }
 }
 
@@ -509,12 +535,48 @@ button:focus-visible,
   cursor: pointer;
   transition: transform 200ms ease, box-shadow 200ms ease;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .btn--primary {
   background: linear-gradient(135deg, rgba(99, 102, 241, 0.98), rgba(56, 189, 248, 0.7));
   color: #f8fafc;
   box-shadow: 0 24px 60px rgba(79, 70, 229, 0.4);
+}
+
+.btn--primary::before {
+  content: "";
+  position: absolute;
+  inset: -35%;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(129, 140, 248, 0.55), transparent 68%);
+  opacity: 0;
+  filter: blur(18px);
+  transition: opacity 320ms ease;
+  z-index: -1;
+}
+
+.btn--primary:hover::before,
+.btn--primary:focus-visible::before {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .btn--primary::before {
+    animation: hero-primary-glow 4.8s ease-in-out infinite;
+  }
+}
+
+@keyframes hero-primary-glow {
+  0%,
+  100% {
+    opacity: 0.22;
+  }
+  45% {
+    opacity: 0.55;
+  }
+  60% {
+    opacity: 0.32;
+  }
 }
 
 .btn--ghost {


### PR DESCRIPTION
## Summary
- refresh the hero copy and CTA layout to emphasize availability and measurable results
- replace the mosaic with a gradient glass portrait card including badge, glow, and parallax depth layers
- update hero styles, CTA glow animation, and tilt script to support the new design in dark mode

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d97b045fe083329011b0521490b75e